### PR TITLE
Add new parameter for json_encode

### DIFF
--- a/src/Gateway/Response.php
+++ b/src/Gateway/Response.php
@@ -54,7 +54,7 @@ class Response
      */
     public function json($data)
     {
-        $this->body = gettype($data) === TYPE_STRING ? $data : json_encode($data);
+        $this->body = gettype($data) === TYPE_STRING ? $data : json_encode($data, JSON_NUMERIC_CHECK);
 
         return $this;
     }


### PR DESCRIPTION
Codifica strings numéricas como números. Disponível desdee o PHP 5.3.3. 

OBS.: eu tive problemas com numeros enviados por json no laravel.

http://php.net/manual/pt_BR/json.constants.php